### PR TITLE
make errors objects instead of strings

### DIFF
--- a/subprotocol/graphql_ws.go
+++ b/subprotocol/graphql_ws.go
@@ -103,7 +103,7 @@ type GraphQLWSOriginResponse struct {
 
 type GraphQLWSResult struct {
 	Data   json.RawMessage
-	Errors []string
+	Errors json.RawMessage
 }
 
 type GraphQLWSSubscription struct {
@@ -146,7 +146,7 @@ type graphQLWSStartPayload struct {
 
 type graphQLWSDataPayload struct {
 	Data   json.RawMessage `json:"data,omitempty"`
-	Errors []string        `json:"errors"`
+	Errors json.RawMessage `json:"errors,omitempty"`
 }
 
 func (sp *GraphQLWS) init() {
@@ -291,7 +291,7 @@ func (sp *GraphQLWS) graphQLWSMessageWithGraphQLResult(id string, result *GraphQ
 		return &graphQLWSMessage{
 			Id:      id,
 			Type:    graphQLWSMessageTypeError,
-			Payload: json.RawMessage(`"An internal error has occurred."`),
+			Payload: json.RawMessage(`[{"message": "An internal error has occurred."}]`),
 		}
 	}
 	return &graphQLWSMessage{
@@ -415,9 +415,13 @@ func (sp *GraphQLWS) handleOriginRequest(r *wss.OriginRequest) {
 
 		if response != nil {
 			if response.Error != "" {
-				payload, err := jsoniter.Marshal(response.Error)
+				payload, err := jsoniter.Marshal([]struct {
+					Message string `json:"message"`
+				}{
+					{Message: response.Error},
+				})
 				if err != nil {
-					payload = []byte(`"An internal error has occurred."`)
+					payload = []byte(`[{"message": "An internal error has occurred."}]`)
 				}
 				outgoing = append(outgoing, &graphQLWSMessage{
 					Id:      msg.Id,

--- a/subprotocol/graphql_ws.go
+++ b/subprotocol/graphql_ws.go
@@ -291,7 +291,7 @@ func (sp *GraphQLWS) graphQLWSMessageWithGraphQLResult(id string, result *GraphQ
 		return &graphQLWSMessage{
 			Id:      id,
 			Type:    graphQLWSMessageTypeError,
-			Payload: json.RawMessage(`[{"message": "An internal error has occurred."}]`),
+			Payload: json.RawMessage(`{"message": "An internal error has occurred."}`),
 		}
 	}
 	return &graphQLWSMessage{
@@ -415,13 +415,13 @@ func (sp *GraphQLWS) handleOriginRequest(r *wss.OriginRequest) {
 
 		if response != nil {
 			if response.Error != "" {
-				payload, err := jsoniter.Marshal([]struct {
+				payload, err := jsoniter.Marshal(struct {
 					Message string `json:"message"`
 				}{
-					{Message: response.Error},
+					Message: response.Error,
 				})
 				if err != nil {
-					payload = []byte(`[{"message": "An internal error has occurred."}]`)
+					payload = []byte(`{"message": "An internal error has occurred."}`)
 				}
 				outgoing = append(outgoing, &graphQLWSMessage{
 					Id:      msg.Id,


### PR DESCRIPTION
Errors should be GraphQL error objects instead of strings. See https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md.

This is technically backwards-incompatible for non-conforming clients, but it's a bug fix and only relevant in error cases. It's backwards-compatible with origins and will just forward whatever errors the origin provides. (So there will also be an AAF platform PR.)