### PR TITLE
allow absent errors

### DIFF
--- a/subprotocol/graphql_ws.go
+++ b/subprotocol/graphql_ws.go
@@ -103,7 +103,7 @@ type GraphQLWSOriginResponse struct {
 
 type GraphQLWSResult struct {
 	Data   json.RawMessage
-	Errors json.RawMessage
+	Errors json.RawMessage `json:"Errors,omitempty"`
 }
 
 type GraphQLWSSubscription struct {


### PR DESCRIPTION
Without this, if the origin doesn't set `Errors`, its responses would be malformed.